### PR TITLE
Drop leftovers from EOL Python version support

### DIFF
--- a/cs/__init__.py
+++ b/cs/__init__.py
@@ -3,11 +3,7 @@ import json
 import os
 import sys
 from collections import defaultdict
-
-try:
-    from configparser import NoSectionError
-except ImportError:  # python 2
-    from ConfigParser import NoSectionError
+from configparser import NoSectionError
 
 try:
     import pygments
@@ -32,15 +28,14 @@ __all__ = [
     "CloudStackApiException",
 ]
 
-if sys.version_info >= (3, 5):
-    try:
-        import aiohttp  # noqa
-    except ImportError:
-        pass
-    else:
-        from ._async import AIOCloudStack  # noqa
+try:
+    import aiohttp  # noqa
+except ImportError:
+    pass
+else:
+    from ._async import AIOCloudStack  # noqa
 
-        __all__.append("AIOCloudStack")
+    __all__.append("AIOCloudStack")
 
 
 def _format_json(data, theme):

--- a/cs/client.py
+++ b/cs/client.py
@@ -1,6 +1,3 @@
-#! /usr/bin/env python
-from __future__ import print_function
-
 import base64
 import hashlib
 import hmac
@@ -8,42 +5,21 @@ import os
 import re
 import sys
 import time
+from configparser import ConfigParser
 from datetime import datetime, timedelta
 from fnmatch import fnmatch
-
-try:
-    from configparser import ConfigParser
-except ImportError:  # python 2
-    from ConfigParser import ConfigParser
-
-try:
-    from urllib.parse import quote
-except ImportError:  # python 2
-    from urllib import quote
+from urllib.parse import quote
 
 import pytz
 
 import requests
 from requests.structures import CaseInsensitiveDict
 
-PY2 = sys.version_info < (3, 0)
 
-if PY2:
-    text_type = unicode  # noqa
-    string_type = basestring  # noqa
-    integer_types = int, long  # noqa
-    binary_type = str
-else:
-    text_type = str
-    string_type = str
-    integer_types = int
-    binary_type = bytes
-
-if sys.version_info >= (3, 5):
-    try:
-        from . import AIOCloudStack  # noqa
-    except ImportError:
-        pass
+try:
+    from . import AIOCloudStack  # noqa
+except ImportError:
+    pass
 
 
 TIMEOUT = 10
@@ -124,8 +100,6 @@ def cs_encode(s):
 
     java.net.URLEncoder.encode(s).replace('+', '%20')
     """
-    if PY2 and isinstance(s, text_type):
-        s = s.encode("utf-8")
     return quote(s, safe="*")
 
 
@@ -146,11 +120,11 @@ def transform(params):
             params.pop(key)
             continue
 
-        if isinstance(value, (string_type, binary_type)):
+        if isinstance(value, (str, bytes)):
             continue
 
-        if isinstance(value, integer_types):
-            params[key] = text_type(value)
+        if isinstance(value, int):
+            params[key] = str(value)
         elif isinstance(value, (list, tuple, set, dict)):
             if not value:
                 params.pop(key)
@@ -166,7 +140,7 @@ def transform(params):
                     for index, val in enumerate(value):
                         for name, v in val.items():
                             k = "%s[%d].%s" % (key, index, name)
-                            params[k] = text_type(v)
+                            params[k] = str(v)
         else:
             raise ValueError(type(value))
 
@@ -606,7 +580,7 @@ def read_config(ini_group=None):
     # convert booleans values.
     bool_keys = ("dangerous_no_tls_verify",)
     for bool_key in bool_keys:
-        if isinstance(config[bool_key], string_type):
+        if isinstance(config[bool_key], str):
             try:
                 config[bool_key] = strtobool(config[bool_key])
             except ValueError:

--- a/tests.py
+++ b/tests.py
@@ -4,16 +4,8 @@ import os
 from contextlib import contextmanager
 from functools import partial
 from unittest import TestCase
-
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-try:
-    from urllib.parse import urlparse, parse_qs
-except ImportError:
-    from urlparse import urlparse, parse_qs
+from unittest.mock import patch
+from urllib.parse import urlparse, parse_qs
 
 from cs import (
     CloudStack,


### PR DESCRIPTION
Versions below 3.8 (including Python 2) are not supported, drop related code.