### PR TITLE
Remove `pytest-runner`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,13 +26,6 @@ zip_safe = false
 install_requires =
     pytz
     requests
-setup_requires =
-    pytest-runner
-tests_require =
-    aiohttp
-    pytest-cache
-    pytest-cov
-    pytest
 
 [options.packages.find]
 exclude = tests

--- a/tox.ini
+++ b/tox.ini
@@ -14,11 +14,14 @@ python =
 
 [testenv]
 deps=
+	aiohttp
 	check-manifest
 	flake8
 	flake8-import-order
+	pytest
+	pytest-cache
+	pytest-cov
 commands =
-	pip install pytest pytest-cache pytest-cov
 	pip wheel --no-deps -w dist .
 	test: pytest -v
 	check-manifest


### PR DESCRIPTION
`pytest-runner` has been considered deprecated upstream since 2019:
https://github.com/pytest-dev/pytest-runner/commit/78a492cb9f611a4fccaf6556c966b848885833ba
and the repo upstream was archived over a year ago (December 3, 2023).

`pytest-runner` is deprecated in Fedora:
https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/XWRCM4AOKM7KOMR3NLXDD2F7G65ALPKJ/#4BGKLXGODMGMDQKTLLYWD3R4NQ27UAJC

Remove `pytest-runner` and fully migrate to `tox`.
